### PR TITLE
prebuilt: add permission for com.google.android.settings.intelligence

### DIFF
--- a/prebuilt/common/etc/permissions/privapp-permissions-palladium.xml
+++ b/prebuilt/common/etc/permissions/privapp-permissions-palladium.xml
@@ -57,4 +57,8 @@
         <permission name="android.permission.WRITE_MEDIA_STORAGE"/>
     </privapp-permissions>
 
+    <privapp-permissions package="com.google.android.settings.intelligence.IntelligenceApplication">
+        <permission name="android.permission.READ_DEVICE_CONFIG"/>
+    </privapp-permissions>
+
 </permissions>


### PR DESCRIPTION
logs-
Unable to create application com.google.android.settings.intelligence.IntelligenceApplication: java.lang.SecurityException: Permission denial: reading from settings requires:android.permission.READ_DEVICE_CONFIG
Caused by: java.lang.SecurityException: Permission denial: reading from settings requires:android.permission.READ_DEVICE_CONFIG